### PR TITLE
Fix Netlify deploy: output to dist/ to match publish dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: 'build',
+    outDir: 'dist',
     sourcemap: true
   }
 })


### PR DESCRIPTION
Vite was writing to build/ while Netlify publishes dist/, causing 'Deploy directory dist does not exist'. Restore outDir: 'dist' and gitignore /dist.